### PR TITLE
Add path support for client socket conifguration

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -6,7 +6,9 @@ export default class Provider extends Component {
   constructor(props) {
     super(props);
 
-    this.socket = io(props.url);
+    this.socket = io(props.url, {
+      path: props.path
+    });
   }
 
   render() {

--- a/src/provider.js
+++ b/src/provider.js
@@ -6,9 +6,7 @@ export default class Provider extends Component {
   constructor(props) {
     super(props);
 
-    this.socket = io(props.url, {
-      path: props.path
-    });
+    this.socket = io(props.url, props.opts || {});
   }
 
   render() {


### PR DESCRIPTION
In some case we may want to configure the path of socket io. That should also be included as a prop option.